### PR TITLE
Add Content page with search, filters, and pagination

### DIFF
--- a/app/content/page.tsx
+++ b/app/content/page.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { Header } from '@/components/shared/Header'
+import { Footer } from '@/components/shared/Footer'
+import { ContentCard } from '@/components/content/ContentCard'
+import { ContentFilters } from '@/components/content/ContentFilters'
+import { Pagination } from '@/components/content/Pagination'
+import { sortedContentData } from '@/data/content'
+import { ContentTag } from '@/types/content'
+import { useScrollToTop } from '@/app/hooks/useScrollToTop'
+
+const ITEMS_PER_PAGE = 9
+
+export default function ContentPage() {
+  useScrollToTop()
+
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedTags, setSelectedTags] = useState<ContentTag[]>([])
+  const [currentPage, setCurrentPage] = useState(1)
+
+  const filteredContent = useMemo(() => {
+    return sortedContentData.filter((item) => {
+      const searchLower = searchQuery.toLowerCase()
+      const matchesSearch =
+        !searchQuery ||
+        item.title.toLowerCase().includes(searchLower) ||
+        item.subtitle.toLowerCase().includes(searchLower) ||
+        item.tags.some((tag) => tag.toLowerCase().includes(searchLower))
+
+      const matchesTags =
+        selectedTags.length === 0 ||
+        selectedTags.some((tag) => item.tags.includes(tag))
+
+      return matchesSearch && matchesTags
+    })
+  }, [searchQuery, selectedTags])
+
+  const totalPages = Math.ceil(filteredContent.length / ITEMS_PER_PAGE)
+
+  const paginatedContent = useMemo(() => {
+    const start = (currentPage - 1) * ITEMS_PER_PAGE
+    return filteredContent.slice(start, start + ITEMS_PER_PAGE)
+  }, [filteredContent, currentPage])
+
+  const handleSearchChange = (query: string) => {
+    setSearchQuery(query)
+    setCurrentPage(1)
+  }
+
+  const handleTagToggle = (tag: ContentTag) => {
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+    )
+    setCurrentPage(1)
+  }
+
+  const handleClearFilters = () => {
+    setSearchQuery('')
+    setSelectedTags([])
+    setCurrentPage(1)
+  }
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page)
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col text-white relative overflow-hidden bg-navy-primary">
+      <Header />
+      <main className="flex-grow container mx-auto px-2 sm:px-3 md:px-4 pt-14 sm:pt-18 md:pt-24 pb-10 sm:pb-14 md:pb-20">
+        <div className="w-full sm:max-w-[95%] md:max-w-[90%] lg:max-w-[80%] xl:max-w-[70%] mx-auto space-y-8 sm:space-y-10 md:space-y-12">
+          {/* Header section */}
+          <section className="text-center">
+            <h1 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold mb-3 sm:mb-4 md:mb-6 bg-gradient-to-r from-blue-400 to-green-400 bg-clip-text text-transparent">
+              Content
+            </h1>
+            <p className="text-base sm:text-lg md:text-xl lg:text-2xl text-gray-300 mb-8 sm:mb-10 md:mb-12">
+              Insights on Engineering, Product, AI, and Productivity
+            </p>
+          </section>
+
+          {/* Filters section */}
+          <section className="bg-white/5 rounded-2xl p-4 sm:p-5 md:p-6 backdrop-blur-sm">
+            <ContentFilters
+              searchQuery={searchQuery}
+              onSearchChange={handleSearchChange}
+              selectedTags={selectedTags}
+              onTagToggle={handleTagToggle}
+              onClearFilters={handleClearFilters}
+              resultCount={filteredContent.length}
+              totalCount={sortedContentData.length}
+            />
+          </section>
+
+          {/* Content grid */}
+          <section>
+            {paginatedContent.length > 0 ? (
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-5 md:gap-6">
+                {paginatedContent.map((item, index) => (
+                  <ContentCard key={item.id} item={item} index={index} />
+                ))}
+              </div>
+            ) : (
+              <div className="text-center py-12">
+                <p className="text-gray-400 text-lg">
+                  No posts found matching your filters.
+                </p>
+                <button
+                  onClick={handleClearFilters}
+                  className="mt-4 text-green-400 hover:text-green-300 transition-colors"
+                >
+                  Clear filters
+                </button>
+              </div>
+            )}
+
+            {/* Pagination */}
+            <Pagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPageChange={handlePageChange}
+            />
+          </section>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/components/content/ContentCard.tsx
+++ b/components/content/ContentCard.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { ContentItem } from '@/types/content'
+import { TagChip } from './TagChip'
+import { motion } from 'framer-motion'
+import { FaExternalLinkAlt } from 'react-icons/fa'
+
+interface ContentCardProps {
+  item: ContentItem
+  index: number
+}
+
+export function ContentCard({ item, index }: ContentCardProps) {
+  return (
+    <motion.a
+      href={item.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{
+        duration: 0.4,
+        delay: index * 0.05,
+        ease: 'easeOut'
+      }}
+      whileHover={{ scale: 1.02 }}
+      className="group relative block bg-white/5 rounded-xl overflow-hidden hover:bg-white/10 transition-colors cursor-pointer"
+    >
+      <div className="absolute inset-0 z-0">
+        <div className="absolute inset-0 bg-gradient-to-br from-purple-900/40 via-blue-900/30 to-green-900/20"></div>
+      </div>
+
+      <div className="relative z-10 p-4 sm:p-5 md:p-6 flex flex-col h-full min-h-[200px] sm:min-h-[220px]">
+        {/* Header: Title + External link icon */}
+        <div className="flex justify-between items-start gap-2 mb-2">
+          <h3
+            className="text-sm sm:text-base font-semibold text-white leading-tight line-clamp-2 group-hover:text-green-400 transition-colors"
+            title={item.title}
+          >
+            {item.title}
+          </h3>
+          <FaExternalLinkAlt className="text-gray-400 group-hover:text-green-400 transition-colors flex-shrink-0 w-3 h-3 mt-1" />
+        </div>
+
+        {/* Subtitle with tooltip on hover */}
+        <p
+          className="text-xs sm:text-sm text-gray-300 line-clamp-3 flex-grow mb-4"
+          title={item.subtitle}
+        >
+          {item.subtitle}
+        </p>
+
+        {/* Footer: Tags on top, Date below aligned left */}
+        <div className="mt-auto space-y-2">
+          <div className="flex flex-wrap gap-1.5">
+            {item.tags.map((tag) => (
+              <TagChip key={tag} tag={tag} size="sm" />
+            ))}
+          </div>
+          <span className="text-xs text-gray-400 block">{item.formattedDate}</span>
+        </div>
+      </div>
+    </motion.a>
+  )
+}

--- a/components/content/ContentFilters.tsx
+++ b/components/content/ContentFilters.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { ContentTag } from '@/types/content'
+import { TagChip } from './TagChip'
+import { FaSearch, FaTimes } from 'react-icons/fa'
+
+interface ContentFiltersProps {
+  searchQuery: string
+  onSearchChange: (query: string) => void
+  selectedTags: ContentTag[]
+  onTagToggle: (tag: ContentTag) => void
+  onClearFilters: () => void
+  resultCount: number
+  totalCount: number
+}
+
+const ALL_TAGS: ContentTag[] = ['AI', 'Engineering', 'Product', 'Productivity', 'Analysis']
+
+export function ContentFilters({
+  searchQuery,
+  onSearchChange,
+  selectedTags,
+  onTagToggle,
+  onClearFilters,
+  resultCount,
+  totalCount
+}: ContentFiltersProps) {
+  const hasActiveFilters = searchQuery.length > 0 || selectedTags.length > 0
+
+  return (
+    <div className="space-y-4">
+      {/* Search input */}
+      <div className="relative">
+        <FaSearch className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
+        <input
+          type="text"
+          placeholder="Search posts..."
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="w-full bg-white/5 rounded-xl pl-11 pr-4 py-3 text-white placeholder-gray-400 border border-white/10 focus:border-green-400 focus:outline-none transition-colors"
+        />
+        {searchQuery && (
+          <button
+            onClick={() => onSearchChange('')}
+            className="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white transition-colors"
+          >
+            <FaTimes className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Tag filters */}
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm text-gray-400 mr-1">Filter:</span>
+        {ALL_TAGS.map((tag) => (
+          <TagChip
+            key={tag}
+            tag={tag}
+            size="md"
+            isActive={selectedTags.includes(tag)}
+            onClick={() => onTagToggle(tag)}
+          />
+        ))}
+
+        {hasActiveFilters && (
+          <button
+            onClick={onClearFilters}
+            className="ml-2 text-sm text-gray-400 hover:text-white transition-colors flex items-center gap-1"
+          >
+            <FaTimes className="w-3 h-3" />
+            Clear
+          </button>
+        )}
+      </div>
+
+      {/* Result count */}
+      {hasActiveFilters && (
+        <p className="text-sm text-gray-400">
+          Showing {resultCount} of {totalCount} posts
+        </p>
+      )}
+    </div>
+  )
+}

--- a/components/content/Pagination.tsx
+++ b/components/content/Pagination.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa'
+
+interface PaginationProps {
+  currentPage: number
+  totalPages: number
+  onPageChange: (page: number) => void
+}
+
+export function Pagination({ currentPage, totalPages, onPageChange }: PaginationProps) {
+  if (totalPages <= 1) return null
+
+  const getPageNumbers = () => {
+    const pages: (number | string)[] = []
+
+    if (totalPages <= 7) {
+      for (let i = 1; i <= totalPages; i++) {
+        pages.push(i)
+      }
+    } else {
+      pages.push(1)
+
+      if (currentPage > 3) {
+        pages.push('...')
+      }
+
+      const start = Math.max(2, currentPage - 1)
+      const end = Math.min(totalPages - 1, currentPage + 1)
+
+      for (let i = start; i <= end; i++) {
+        pages.push(i)
+      }
+
+      if (currentPage < totalPages - 2) {
+        pages.push('...')
+      }
+
+      pages.push(totalPages)
+    }
+
+    return pages
+  }
+
+  return (
+    <div className="flex justify-center items-center gap-2 mt-8">
+      <motion.button
+        whileHover={{ scale: 1.1 }}
+        whileTap={{ scale: 0.95 }}
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 1}
+        className="p-2 rounded-lg bg-white/5 text-gray-300 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        <FaChevronLeft className="w-4 h-4" />
+      </motion.button>
+
+      {getPageNumbers().map((page, index) => (
+        typeof page === 'number' ? (
+          <motion.button
+            key={index}
+            whileHover={{ scale: 1.1 }}
+            whileTap={{ scale: 0.95 }}
+            onClick={() => onPageChange(page)}
+            className={`w-10 h-10 rounded-lg font-medium transition-colors ${
+              currentPage === page
+                ? 'bg-green-500 text-white'
+                : 'bg-white/5 text-gray-300 hover:bg-white/10'
+            }`}
+          >
+            {page}
+          </motion.button>
+        ) : (
+          <span key={index} className="px-2 text-gray-400">
+            {page}
+          </span>
+        )
+      ))}
+
+      <motion.button
+        whileHover={{ scale: 1.1 }}
+        whileTap={{ scale: 0.95 }}
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage === totalPages}
+        className="p-2 rounded-lg bg-white/5 text-gray-300 hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        <FaChevronRight className="w-4 h-4" />
+      </motion.button>
+    </div>
+  )
+}

--- a/components/content/TagChip.tsx
+++ b/components/content/TagChip.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { ContentTag } from '@/types/content'
+import { motion } from 'framer-motion'
+
+interface TagChipProps {
+  tag: ContentTag
+  isActive?: boolean
+  onClick?: () => void
+  size?: 'sm' | 'md'
+}
+
+const tagColors: Record<ContentTag, { bg: string; text: string; activeBg: string }> = {
+  'Productivity': {
+    bg: 'bg-yellow-500/10',
+    text: 'text-yellow-300',
+    activeBg: 'bg-yellow-500/30 border-yellow-400'
+  },
+  'Engineering': {
+    bg: 'bg-blue-500/10',
+    text: 'text-blue-300',
+    activeBg: 'bg-blue-500/30 border-blue-400'
+  },
+  'Product': {
+    bg: 'bg-purple-500/10',
+    text: 'text-purple-300',
+    activeBg: 'bg-purple-500/30 border-purple-400'
+  },
+  'AI': {
+    bg: 'bg-green-500/10',
+    text: 'text-green-300',
+    activeBg: 'bg-green-500/30 border-green-400'
+  },
+  'Analysis': {
+    bg: 'bg-orange-500/10',
+    text: 'text-orange-300',
+    activeBg: 'bg-orange-500/30 border-orange-400'
+  }
+}
+
+export function TagChip({ tag, isActive = false, onClick, size = 'sm' }: TagChipProps) {
+  const colors = tagColors[tag]
+  const isClickable = !!onClick
+
+  const sizeClasses = size === 'sm'
+    ? 'px-2 py-0.5 text-xs'
+    : 'px-3 py-1 text-sm'
+
+  const baseClasses = `
+    inline-flex items-center rounded-full font-medium transition-all
+    ${sizeClasses}
+    ${colors.text}
+    ${isActive ? colors.activeBg : colors.bg}
+    ${isActive ? 'border' : 'border border-transparent'}
+    ${isClickable ? 'cursor-pointer hover:scale-105' : ''}
+  `
+
+  if (isClickable) {
+    return (
+      <motion.button
+        type="button"
+        onClick={onClick}
+        className={baseClasses}
+        whileHover={{ scale: 1.05 }}
+        whileTap={{ scale: 0.95 }}
+      >
+        {tag}
+      </motion.button>
+    )
+  }
+
+  return (
+    <span className={baseClasses}>
+      {tag}
+    </span>
+  )
+}

--- a/components/shared/Header.tsx
+++ b/components/shared/Header.tsx
@@ -9,7 +9,7 @@ export function Header() {
           <nav className="flex space-x-2">
             <Link key="about-link" href="/about" className="text-sm md:text-base font-medium text-gray-300 hover:text-green-400 transition-colors px-2 md:px-3 py-1 md:py-2">About</Link>
             <Link key="projects-link" href="/projects" className="text-sm md:text-base font-medium text-gray-300 hover:text-green-400 transition-colors px-2 md:px-3 py-1 md:py-2">Projects</Link>
-            <Link key="blog-link" href="https://blog.matangr.com/" className="text-sm md:text-base font-medium text-gray-300 hover:text-green-400 transition-colors px-2 md:px-3 py-1 md:py-2">Blog</Link>
+            <Link key="content-link" href="/content" className="text-sm md:text-base font-medium text-gray-300 hover:text-green-400 transition-colors px-2 md:px-3 py-1 md:py-2">Content</Link>
           </nav>
         </div>
       </div>

--- a/data/content.ts
+++ b/data/content.ts
@@ -1,0 +1,531 @@
+import { ContentItem } from '@/types/content'
+
+export const contentData: ContentItem[] = [
+  {
+    id: '57-on-context-engineering',
+    title: '#57 - On Context Engineering',
+    subtitle: 'What Is Context Engineering, and How It Can Drive AI Adoption',
+    date: new Date('2025-08-13T07:05:05.260Z'),
+    formattedDate: 'Aug 13, 2025',
+    tags: ['AI', 'Engineering'],
+    url: 'https://blog.matangr.com/p/57-on-context-engineering'
+  },
+  {
+    id: '56-my-ai-agent-required-more-engineering',
+    title: '#56 - My AI agent required more engineering than prompts',
+    subtitle: 'A case study on automating release changelogs and the messy work of building production-ready AI.',
+    date: new Date('2025-07-22T14:55:32.229Z'),
+    formattedDate: 'Jul 22, 2025',
+    tags: ['AI', 'Engineering'],
+    url: 'https://blog.matangr.com/p/my-ai-agent-required-more-engineering'
+  },
+  {
+    id: '55-domain-driven-ai',
+    title: '#55 - Domain-driven AI',
+    subtitle: 'Why AI Needs Domain-Driven Design to Overcome Language Barriers',
+    date: new Date('2025-07-10T20:48:52.120Z'),
+    formattedDate: 'Jul 10, 2025',
+    tags: ['AI', 'Engineering'],
+    url: 'https://blog.matangr.com/p/domain-driven-ai'
+  },
+  {
+    id: '54-building-my-first-google-sheets-add',
+    title: '#54 - Building My First Google Sheets Add-on',
+    subtitle: 'The unexpected challenges of building, testing, and publishing a Google Sheets add-on',
+    date: new Date('2025-05-27T20:12:56.238Z'),
+    formattedDate: 'May 27, 2025',
+    tags: ['Engineering'],
+    url: 'https://blog.matangr.com/p/building-my-first-google-sheets-add'
+  },
+  {
+    id: '53-building-an-mcp-server',
+    title: '#53 - Building an MCP Server',
+    subtitle: 'The unexpected challenges of building, testing, and deploying an MCP server—and what I learned along the way.',
+    date: new Date('2025-03-11T18:46:02.623Z'),
+    formattedDate: 'Mar 11, 2025',
+    tags: ['AI', 'Engineering'],
+    url: 'https://blog.matangr.com/p/53-building-an-mcp-server'
+  },
+  {
+    id: '52-wearing-a-developers-hat-for-a-few',
+    title: "#52 - Wearing a Developer's Hat for a Few Weeks",
+    subtitle: 'Lessons from developing an internal tool to integrate systems',
+    date: new Date('2025-01-26T12:46:58.520Z'),
+    formattedDate: 'Jan 26, 2025',
+    tags: ['Engineering'],
+    url: 'https://blog.matangr.com/p/wearing-a-developers-hat-for-a-few'
+  },
+  {
+    id: '51-succeed-by-taking-one-step-at',
+    title: '#51 - Succeed by Taking One Step at a Time',
+    subtitle: 'How I almost lost an entire project by working in large batches, and lessons learned',
+    date: new Date('2025-01-07T06:41:35.500Z'),
+    formattedDate: 'Jan 7, 2025',
+    tags: ['Productivity'],
+    url: 'https://blog.matangr.com/p/51-succeed-by-taking-one-step-at'
+  },
+  {
+    id: '55-small-doesnt-mean-fast',
+    title: "#58 - Small doesn't mean fast",
+    subtitle: 'My detailed experience delivering a "small" feature to production, and why it took over two days',
+    date: new Date('2025-12-01T18:28:25.049Z'),
+    formattedDate: 'Dec 1, 2025',
+    tags: ['Engineering', 'Product'],
+    url: 'https://blog.matangr.com/p/55-small-doesnt-mean-fast'
+  },
+  {
+    id: '50-is-ai-a-faster-horse-or-the-next',
+    title: '#50 - Is AI A Faster Horse or the Next Tesla?',
+    subtitle: 'How Generative AI is Transforming Technology, Business Models, and Our Approach to Problem-Solving',
+    date: new Date('2024-12-18T20:19:20.847Z'),
+    formattedDate: 'Dec 18, 2024',
+    tags: ['AI'],
+    url: 'https://blog.matangr.com/p/50-is-ai-a-faster-horse-or-the-next'
+  },
+  {
+    id: '49-how-i-reduced-costs-by-85-using-ai',
+    title: '#49 - How I Reduced Costs by 85% Using AI',
+    subtitle: 'Leveraging AI and free hosting to create a sleek, affordable site',
+    date: new Date('2024-12-02T07:03:22.416Z'),
+    formattedDate: 'Dec 2, 2024',
+    tags: ['AI'],
+    url: 'https://blog.matangr.com/p/how-i-reduced-costs-by-85-using-ai'
+  },
+  {
+    id: '48-testing-culture',
+    title: '#48 - Testing Culture',
+    subtitle: 'Explore how software testing strategies can reveal valuable insights into your organization',
+    date: new Date('2024-11-13T20:21:02.093Z'),
+    formattedDate: 'Nov 13, 2024',
+    tags: ['Engineering'],
+    url: 'https://blog.matangr.com/p/48-testing-culture'
+  },
+  {
+    id: '47-efficient-data-management-strategies',
+    title: '#47 - Efficient Data Management Strategies',
+    subtitle: 'How ETL and Reverse ETL Transform Knowledge Work and Improve Efficiency',
+    date: new Date('2024-11-05T20:20:02.436Z'),
+    formattedDate: 'Nov 5, 2024',
+    tags: ['Engineering', 'Productivity', 'Analysis'],
+    url: 'https://blog.matangr.com/p/47-efficient-data-management-strategies'
+  },
+  {
+    id: '46-managing-incidents-in-code-and',
+    title: '#46 - Managing Incidents in Code and Beyond',
+    subtitle: 'Key concepts from production incidents applied to unstructured problems',
+    date: new Date('2024-10-20T19:58:55.638Z'),
+    formattedDate: 'Oct 20, 2024',
+    tags: ['Engineering', 'Analysis'],
+    url: 'https://blog.matangr.com/p/46-managing-incidents-in-code-and'
+  },
+  {
+    id: '45-keeping-okrs-relevant-with-virtual',
+    title: '#45 - Keeping OKRs Relevant with Virtual DOM',
+    subtitle: 'Applying Virtual DOM Concepts to Keep OKRs Relevant and Efficient',
+    date: new Date('2024-10-14T07:02:48.520Z'),
+    formattedDate: 'Oct 14, 2024',
+    tags: ['Product', 'Productivity'],
+    url: 'https://blog.matangr.com/p/45-keeping-okrs-relevant-with-virtual'
+  },
+  {
+    id: '44-learning-from-the-past-with-decision',
+    title: '#44 - Learning from the Past with Decision Logs',
+    subtitle: 'How Git Commit Practices Can Help Track and Improve Decisions Over Time',
+    date: new Date('2024-10-09T20:52:59.638Z'),
+    formattedDate: 'Oct 9, 2024',
+    tags: ['Engineering', 'Product', 'Analysis'],
+    url: 'https://blog.matangr.com/p/44-learning-from-the-past-with-decision'
+  },
+  {
+    id: '43-risk-metrics-before-success-metrics',
+    title: '#43 - Risk Metrics Before Success Metrics',
+    subtitle: 'From Risk Metrics to Actionable Insights',
+    date: new Date('2024-10-04T19:51:55.550Z'),
+    formattedDate: 'Oct 4, 2024',
+    tags: ['Analysis'],
+    url: 'https://blog.matangr.com/p/43-risk-metrics-before-success-metrics'
+  },
+  {
+    id: '42-breaking-down-metrics-to-build',
+    title: '#42 - Breaking Down Metrics to Build Up Success',
+    subtitle: 'Using the KPI Tree Approach to Create Impactful Working Agreements',
+    date: new Date('2024-09-23T13:57:25.374Z'),
+    formattedDate: 'Sep 23, 2024',
+    tags: ['Product', 'Analysis'],
+    url: 'https://blog.matangr.com/p/42-breaking-down-metrics-to-build'
+  },
+  {
+    id: '41-decision-making-without-full-context',
+    title: '#41 - Decision-Making Without Full Context',
+    subtitle: 'Applying Software Patterns to Make Quick, Effective Decisions',
+    date: new Date('2024-09-15T07:35:46.205Z'),
+    formattedDate: 'Sep 15, 2024',
+    tags: ['Engineering', 'Product', 'Analysis'],
+    url: 'https://blog.matangr.com/p/41-decision-making-without-full-context'
+  },
+  {
+    id: '40-context-in-software-design',
+    title: '#40 - Context in Software Design',
+    subtitle: 'How Managing Information Improves Decisions and Reduces Complexity',
+    date: new Date('2024-09-08T19:32:31.854Z'),
+    formattedDate: 'Sep 8, 2024',
+    tags: ['Engineering', 'Product', 'Analysis'],
+    url: 'https://blog.matangr.com/p/40-context-in-software-design'
+  },
+  {
+    id: '39-event-driven-tracking',
+    title: '#39 - Event-Driven Tracking',
+    subtitle: 'Using Event Sourcing Concepts to Gain Clearer Insights',
+    date: new Date('2024-08-20T19:50:29.893Z'),
+    formattedDate: 'Aug 20, 2024',
+    tags: ['Engineering', 'Analysis'],
+    url: 'https://blog.matangr.com/p/39-event-driven-tracking'
+  },
+  {
+    id: '38-golden-paths-for-efficiency',
+    title: '#38 - Golden Paths for Efficiency',
+    subtitle: 'How standardized workflows can streamline your organization',
+    date: new Date('2024-08-12T19:25:40.539Z'),
+    formattedDate: 'Aug 12, 2024',
+    tags: ['Productivity'],
+    url: 'https://blog.matangr.com/p/38-golden-paths-for-efficiency'
+  },
+  {
+    id: '37-idempotency-in-action',
+    title: '#37 - Idempotency in Action',
+    subtitle: 'Ensuring Reliable Outcomes and Enhancing Resilience',
+    date: new Date('2024-08-05T09:07:01.175Z'),
+    formattedDate: 'Aug 5, 2024',
+    tags: ['Engineering'],
+    url: 'https://blog.matangr.com/p/37-idempotency-in-action'
+  },
+  {
+    id: '36-online-vs-offline-approaches',
+    title: '#36 - Online vs Offline Approaches',
+    subtitle: 'Balancing Fresh Data and System Resilience',
+    date: new Date('2024-07-29T05:31:01.067Z'),
+    formattedDate: 'Jul 29, 2024',
+    tags: ['Engineering', 'Analysis'],
+    url: 'https://blog.matangr.com/p/36-online-vs-offline-approaches'
+  },
+  {
+    id: '35-lessons-from-api-communication',
+    title: '#35 - Lessons from API Communication',
+    subtitle: 'Learn Communication Hacks and Tips from API Design',
+    date: new Date('2024-07-17T14:40:00.496Z'),
+    formattedDate: 'Jul 17, 2024',
+    tags: ['Engineering'],
+    url: 'https://blog.matangr.com/p/35-lessons-from-api-communication'
+  },
+  {
+    id: '34-enhancing-alignment-using-git',
+    title: '#34 - Enhancing Alignment Using Git',
+    subtitle: 'Applying Git Commands to Organizational Alignment',
+    date: new Date('2024-07-15T06:00:36.811Z'),
+    formattedDate: 'Jul 15, 2024',
+    tags: ['Engineering', 'Product'],
+    url: 'https://blog.matangr.com/p/34-enhancing-alignment-using-git'
+  },
+  {
+    id: '33-high-availability-patterns-explained',
+    title: '#33 - High Availability Patterns Explained',
+    subtitle: 'How Your Favorite Restaurant Can Teach You About Cloud Infrastructure',
+    date: new Date('2024-07-04T12:58:58.051Z'),
+    formattedDate: 'Jul 4, 2024',
+    tags: ['Engineering'],
+    url: 'https://blog.matangr.com/p/33-high-availability-patterns-explained'
+  },
+  {
+    id: '32-optimizing-interactions-with-genai',
+    title: '#32 - Optimizing Interactions with GenAI',
+    subtitle: 'Using Everyday Communication Tools to Get the Best Out of GenAI',
+    date: new Date('2024-06-30T19:15:55.837Z'),
+    formattedDate: 'Jun 30, 2024',
+    tags: ['AI'],
+    url: 'https://blog.matangr.com/p/optimizing-interactions-with-genai'
+  },
+  {
+    id: '31-micro-frontend-inspired-dependency',
+    title: '#31 - Micro-Frontend Inspired Dependency Management',
+    subtitle: 'Streamlining Team Collaboration by Decoupling Dependencies with Micro-Frontend Architecture',
+    date: new Date('2024-06-26T18:06:45.476Z'),
+    formattedDate: 'Jun 26, 2024',
+    tags: ['Engineering', 'Product'],
+    url: 'https://blog.matangr.com/p/micro-frontend-inspired-dependency'
+  },
+  {
+    id: '30-the-power-of-pulling',
+    title: '#30 - The Power Of Pulling',
+    subtitle: 'Insights we can draw from Pulling (Kanban, TPS, Git) to our day-to-day tasks',
+    date: new Date('2024-01-14T07:09:30.868Z'),
+    formattedDate: 'Jan 14, 2024',
+    tags: ['Engineering', 'Productivity'],
+    url: 'https://blog.matangr.com/p/30-the-power-of-pulling'
+  },
+  {
+    id: '29-vectorized-communication',
+    title: '#29 - Vectorized Communication',
+    subtitle: 'How we can improve internal communication with four practices inspired from Vectorized Databases',
+    date: new Date('2023-09-27T06:16:52.465Z'),
+    formattedDate: 'Sep 27, 2023',
+    tags: ['Engineering', 'Analysis'],
+    url: 'https://blog.matangr.com/p/29-vectorized-communication'
+  },
+  {
+    id: '28-how-technical-tradeoffs-shape',
+    title: '#28 - How Technical Tradeoffs Shape Outcomes',
+    subtitle: 'How technical decisions like environments and deployment pipelines impact the product experience, and why we should care',
+    date: new Date('2023-09-16T18:19:20.090Z'),
+    formattedDate: 'Sep 16, 2023',
+    tags: ['Engineering', 'Product', 'Analysis'],
+    url: 'https://blog.matangr.com/p/28-how-technical-tradeoffs-shape'
+  },
+  {
+    id: '27-monitor-inefficiencies',
+    title: '#27 - Monitor Inefficiencies',
+    subtitle: 'The best way to measure productivity is monitoring inefficiencies',
+    date: new Date('2023-09-07T17:59:50.681Z'),
+    formattedDate: 'Sep 7, 2023',
+    tags: ['Productivity', 'Analysis'],
+    url: 'https://blog.matangr.com/p/27-monitor-inefficiencies'
+  },
+  {
+    id: '26-apis-inspired-dependencies-management',
+    title: '#26 - APIs Inspired Dependencies Management',
+    subtitle: 'How to reduce dependencies between Product teams by taking inspiration from APIs',
+    date: new Date('2023-08-22T11:15:26.477Z'),
+    formattedDate: 'Aug 22, 2023',
+    tags: ['Engineering', 'Product'],
+    url: 'https://blog.matangr.com/p/26-apis-inspired-dependencies-management'
+  },
+  {
+    id: 'three-effective-ways-to-break-deadlocks-1f1f677e433e',
+    title: 'Three Effective Ways to Break Deadlocks',
+    subtitle: 'What is a deadlock, and how can we creatively solve it',
+    date: new Date('2023-07-19T06:43:13.528Z'),
+    formattedDate: 'Jul 19, 2023',
+    tags: ['Engineering', 'Product'],
+    url: 'https://blog.matangr.com/p/three-effective-ways-to-break-deadlocks-1f1f677e433e'
+  },
+  {
+    id: '3-techniques-to-measure-product-debt-2e58de3f5345',
+    title: '3 Techniques To Measure Product Debt',
+    subtitle: 'How to quantify product (tech) debt to reach better decisions',
+    date: new Date('2023-05-30T06:24:10.239Z'),
+    formattedDate: 'May 30, 2023',
+    tags: ['Product', 'Analysis'],
+    url: 'https://blog.matangr.com/p/3-techniques-to-measure-product-debt-2e58de3f5345'
+  },
+  {
+    id: 'cache-inspired-knowledge-management-6cea463cb530',
+    title: 'Cache-Inspired Knowledge Management',
+    subtitle: 'How to increase trust in knowledge management by setting expiration and ownership',
+    date: new Date('2023-05-23T06:11:46.972Z'),
+    formattedDate: 'May 23, 2023',
+    tags: ['Engineering', 'Productivity'],
+    url: 'https://blog.matangr.com/p/cache-inspired-knowledge-management-6cea463cb530'
+  },
+  {
+    id: 'applying-conways-law-navigating-the-build-vs-buy-dilemma-5b4d80b34091',
+    title: "Applying Conway's Law: Navigating the Build vs. Buy Dilemma",
+    subtitle: "Improve decision-making by using Conway's Law",
+    date: new Date('2023-05-15T06:40:20.506Z'),
+    formattedDate: 'May 15, 2023',
+    tags: ['Engineering', 'Product'],
+    url: 'https://blog.matangr.com/p/applying-conways-law-navigating-the-build-vs-buy-dilemma-5b4d80b34091'
+  },
+  {
+    id: 'using-citizenship-and-subdomains-to-improve-decision-making-fe98cd0fe7ba',
+    title: 'Using Citizenship and Subdomains to Improve Decision-making',
+    subtitle: 'Prioritize more effectively using programming citizenship and subdomains concepts',
+    date: new Date('2023-04-23T06:12:00.226Z'),
+    formattedDate: 'Apr 23, 2023',
+    tags: ['Product'],
+    url: 'https://blog.matangr.com/p/using-citizenship-and-subdomains-to-improve-decision-making-fe98cd0fe7ba'
+  },
+  {
+    id: 'the-story-of-alignment-75ac489f3225',
+    title: 'The Story Of Alignment',
+    subtitle: 'What happens when it is missing, and how to overcome it',
+    date: new Date('2023-02-24T20:26:35.619Z'),
+    formattedDate: 'Feb 24, 2023',
+    tags: ['Product'],
+    url: 'https://blog.matangr.com/p/the-story-of-alignment-75ac489f3225'
+  },
+  {
+    id: 'more-with-less-resourcefulness-pt-3-6a7526c6a090',
+    title: 'More with Less — Resourcefulness (Pt. 3)',
+    subtitle: 'Resourcefulness is an essential skill that can help do more with less',
+    date: new Date('2023-02-08T07:40:18.672Z'),
+    formattedDate: 'Feb 8, 2023',
+    tags: ['Productivity'],
+    url: 'https://blog.matangr.com/p/more-with-less-resourcefulness-pt-3-6a7526c6a090'
+  },
+  {
+    id: 'more-with-less-focus-on-impact-pt-2-5afb869094b1',
+    title: 'More With Less — Focus on Impact (Pt. 2)',
+    subtitle: 'Do more by utilizing limited resources to achieve tremendous success.',
+    date: new Date('2023-01-09T03:43:10.935Z'),
+    formattedDate: 'Jan 9, 2023',
+    tags: ['Productivity'],
+    url: 'https://blog.matangr.com/p/more-with-less-focus-on-impact-pt-2-5afb869094b1'
+  },
+  {
+    id: 'more-with-less-identify-waste-pt-1-of-3-468962716f80',
+    title: 'More With Less — Identify Waste (Pt. 1 of 3)',
+    subtitle: 'Improving agility by reducing waste can help do more with less.',
+    date: new Date('2022-12-29T12:54:32.842Z'),
+    formattedDate: 'Dec 29, 2022',
+    tags: ['Productivity'],
+    url: 'https://blog.matangr.com/p/more-with-less-identify-waste-pt-1-of-3-468962716f80'
+  },
+  {
+    id: 'sync-or-async-choosing-the-right-approach-fa8b14fa92eb',
+    title: 'Sync or Async: Choosing the Right Approach',
+    subtitle: 'The basics of sync and async activities and how to benefit from both worlds',
+    date: new Date('2022-12-21T11:53:46.189Z'),
+    formattedDate: 'Dec 21, 2022',
+    tags: ['Productivity'],
+    url: 'https://blog.matangr.com/p/sync-or-async-choosing-the-right-approach-fa8b14fa92eb'
+  },
+  {
+    id: 'from-technical-debt-to-organizational-wealth-5679afe1c1df',
+    title: 'From Technical Debt to Organizational Wealth',
+    subtitle: 'Why technical debt exists, and how to reach organizational wealth instead',
+    date: new Date('2022-12-14T19:45:23.354Z'),
+    formattedDate: 'Dec 14, 2022',
+    tags: ['Engineering', 'Product'],
+    url: 'https://blog.matangr.com/p/from-technical-debt-to-organizational-wealth-5679afe1c1df'
+  },
+  {
+    id: 'dont-forget-the-risk-metrics-da4df593d75e',
+    title: "Don't forget the risk metrics",
+    subtitle: 'Success metrics measure an outcome, while risk metrics monitor unwanted side effects.',
+    date: new Date('2022-11-29T13:08:20.169Z'),
+    formattedDate: 'Nov 29, 2022',
+    tags: ['Analysis'],
+    url: 'https://blog.matangr.com/p/dont-forget-the-risk-metrics-da4df593d75e'
+  },
+  {
+    id: 'focus-on-output-b73cd8fd2258',
+    title: 'Focus on output',
+    subtitle: 'How focusing on the output can help reach the outcome',
+    date: new Date('2022-11-17T05:51:08.815Z'),
+    formattedDate: 'Nov 17, 2022',
+    tags: ['Product'],
+    url: 'https://blog.matangr.com/p/focus-on-output-b73cd8fd2258'
+  },
+  {
+    id: 'how-to-find-the-right-questions-b3b64c2be139',
+    title: 'How to find the right questions',
+    subtitle: 'Find the right questions to ask using The Five Whys technique',
+    date: new Date('2022-10-30T10:57:04.167Z'),
+    formattedDate: 'Oct 30, 2022',
+    tags: ['Analysis'],
+    url: 'https://blog.matangr.com/p/how-to-find-the-right-questions-b3b64c2be139'
+  },
+  {
+    id: 'design-for-the-worst-case-40bc368f1861',
+    title: 'Design for the worst-case',
+    subtitle: 'How to find the unhappy path and design user experience around it',
+    date: new Date('2022-10-12T12:56:16.085Z'),
+    formattedDate: 'Oct 12, 2022',
+    tags: ['Product'],
+    url: 'https://blog.matangr.com/p/design-for-the-worst-case-40bc368f1861'
+  },
+  {
+    id: 'event-driven-communication-cd86465de277',
+    title: 'Event-driven communication',
+    subtitle: 'How to improve internal communication, based on insights from event-driven architecture',
+    date: new Date('2022-09-08T03:11:42.627Z'),
+    formattedDate: 'Sep 8, 2022',
+    tags: ['Engineering'],
+    url: 'https://blog.matangr.com/p/event-driven-communication-cd86465de277'
+  },
+  {
+    id: 'improve-efficiency-with-better-knowledge-management-cf064403b4e',
+    title: 'Improve efficiency with better knowledge management',
+    subtitle: 'How to make knowledge more available to improve productivity and efficiency',
+    date: new Date('2022-07-26T05:42:49.789Z'),
+    formattedDate: 'Jul 26, 2022',
+    tags: ['Productivity'],
+    url: 'https://blog.matangr.com/p/improve-efficiency-with-better-knowledge-management-cf064403b4e'
+  },
+  {
+    id: 'to-add-or-not-to-add-d86b3cab3628',
+    title: 'To Add Or Not To Add',
+    subtitle: 'Why staffing in software projects can delay schedules, and what should we consider instead',
+    date: new Date('2022-07-17T08:52:45.835Z'),
+    formattedDate: 'Jul 17, 2022',
+    tags: ['Engineering', 'Product'],
+    url: 'https://blog.matangr.com/p/to-add-or-not-to-add-d86b3cab3628'
+  },
+  {
+    id: '3-ways-to-improve-deep-work-a62041558203',
+    title: '3 Ways To Improve Deep Work',
+    subtitle: 'How to focus on improving success in a distracted world',
+    date: new Date('2022-06-29T06:18:04.266Z'),
+    formattedDate: 'Jun 29, 2022',
+    tags: ['Productivity'],
+    url: 'https://blog.matangr.com/p/3-ways-to-improve-deep-work-a62041558203'
+  },
+  {
+    id: 'how-to-plan-better-using-the-johari-window-b182a048f9f3',
+    title: 'How To Plan Better Using The Johari Window',
+    subtitle: 'Boost planning by reducing unknowns and improving self-awareness using the Johari Window',
+    date: new Date('2022-06-21T18:37:24.771Z'),
+    formattedDate: 'Jun 21, 2022',
+    tags: ['Analysis'],
+    url: 'https://blog.matangr.com/p/how-to-plan-better-using-the-johari-window-b182a048f9f3'
+  },
+  {
+    id: 'how-domain-driven-design-can-improve-collaboration-e4cc47f3b100',
+    title: 'How Domain-Driven Design Can Improve Collaboration',
+    subtitle: 'How to reduce complexity and improve internal communication using DDD concepts',
+    date: new Date('2022-06-12T09:49:14.213Z'),
+    formattedDate: 'Jun 12, 2022',
+    tags: ['Engineering', 'Product'],
+    url: 'https://blog.matangr.com/p/how-domain-driven-design-can-improve-collaboration-e4cc47f3b100'
+  },
+  {
+    id: 'inbox-zero-what-and-how-4cc191042015',
+    title: 'Inbox Zero — What And How',
+    subtitle: 'Learn what is Inbox Zero, how to get started, and how it will improve your productivity',
+    date: new Date('2022-06-05T18:27:12.808Z'),
+    formattedDate: 'Jun 5, 2022',
+    tags: ['Productivity'],
+    url: 'https://blog.matangr.com/p/inbox-zero-what-and-how-4cc191042015'
+  },
+  {
+    id: 'noestimates-the-leaner-approach-68fd57bff644',
+    title: '#NoEstimates — The Leaner Approach',
+    subtitle: 'How reducing estimation effort along with a Kanban workflow can improve velocity and reduce waste',
+    date: new Date('2022-05-23T19:10:01.180Z'),
+    formattedDate: 'May 23, 2022',
+    tags: ['Productivity'],
+    url: 'https://blog.matangr.com/p/noestimates-the-leaner-approach-68fd57bff644'
+  },
+  {
+    id: 'why-you-need-to-code-434ee5ed7e3b',
+    title: 'Why You Need To Code',
+    subtitle: 'While coding a small software to help in my team\'s work, I learned important lessons as a Product Manager',
+    date: new Date('2022-05-22T05:28:39.960Z'),
+    formattedDate: 'May 22, 2022',
+    tags: ['Engineering', 'Product'],
+    url: 'https://blog.matangr.com/p/why-you-need-to-code-434ee5ed7e3b'
+  },
+  {
+    id: '3-ways-to-improve-knowledge-sharing-5f80a406b0e0',
+    title: '3 Ways To Improve Knowledge Sharing',
+    subtitle: 'Learn what is knowledge management and how to promote knowledge sharing in your organization',
+    date: new Date('2022-05-17T18:42:15.759Z'),
+    formattedDate: 'May 17, 2022',
+    tags: ['Productivity'],
+    url: 'https://blog.matangr.com/p/3-ways-to-improve-knowledge-sharing-5f80a406b0e0'
+  }
+]
+
+// Pre-sorted by date (newest first)
+export const sortedContentData = [...contentData].sort(
+  (a, b) => b.date.getTime() - a.date.getTime()
+)

--- a/lib/contentUtils.ts
+++ b/lib/contentUtils.ts
@@ -1,0 +1,67 @@
+import { ContentTag } from '@/types/content'
+
+const tagKeywords: Record<ContentTag, string[]> = {
+  'AI': [
+    'ai', 'artificial intelligence', 'genai', 'machine learning',
+    'llm', 'gpt', 'context engineering', 'agent', 'mcp', 'prompt'
+  ],
+  'Engineering': [
+    'code', 'coding', 'developer', 'software', 'api', 'architecture',
+    'technical', 'system', 'git', 'testing', 'production', 'deployment',
+    'infrastructure', 'server', 'database', 'etl', 'cache',
+    'event-driven', 'micro-frontend', 'conway', 'deadlock', 'idempotent',
+    'availability', 'terraform', 'kubernetes', 's3', 'bucket'
+  ],
+  'Product': [
+    'product', 'feature', 'roadmap', 'stakeholder', 'user', 'customer',
+    'okr', 'kpi', 'metrics', 'debt', 'build vs buy', 'decision',
+    'priorit', 'alignment', 'collaboration', 'citizenship', 'subdomain'
+  ],
+  'Productivity': [
+    'productivity', 'efficiency', 'inbox zero', 'deep work', 'focus',
+    'knowledge', 'waste', 'lean', 'kanban', 'resourcefulness',
+    'workflow', 'golden path', 'automation', 'batch'
+  ],
+  'Analysis': [
+    'analysis', 'metric', 'data', 'insight', 'measure', 'risk',
+    'tradeoff', 'strategy', 'planning', 'johari', 'five whys',
+    'decision log', 'incident', 'context'
+  ]
+}
+
+export function assignTags(title: string, subtitle: string): ContentTag[] {
+  const combinedText = `${title} ${subtitle}`.toLowerCase()
+  const assignedTags: ContentTag[] = []
+
+  for (const [tag, keywords] of Object.entries(tagKeywords)) {
+    const hasMatch = keywords.some(keyword =>
+      combinedText.includes(keyword.toLowerCase())
+    )
+    if (hasMatch) {
+      assignedTags.push(tag as ContentTag)
+    }
+  }
+
+  if (assignedTags.length === 0) {
+    assignedTags.push('Product')
+  }
+
+  const priorityOrder: ContentTag[] = ['AI', 'Engineering', 'Product', 'Productivity', 'Analysis']
+  return assignedTags
+    .sort((a, b) => priorityOrder.indexOf(a) - priorityOrder.indexOf(b))
+    .slice(0, 3)
+}
+
+export function generateSubstackUrl(postId: string): string {
+  const slug = postId.split('.').slice(1).join('.')
+  return `https://blog.matangr.com/p/${slug}`
+}
+
+export function formatDate(dateString: string): string {
+  const date = new Date(dateString)
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  })
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 2500",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/types/content.ts
+++ b/types/content.ts
@@ -1,0 +1,16 @@
+export type ContentTag =
+  | 'Productivity'
+  | 'Engineering'
+  | 'Product'
+  | 'AI'
+  | 'Analysis'
+
+export interface ContentItem {
+  id: string
+  title: string
+  subtitle: string
+  date: Date
+  formattedDate: string
+  tags: ContentTag[]
+  url: string
+}


### PR DESCRIPTION
## Summary

- New `/content` page replacing external Blog link in navigation
- Displays 57 Substack posts with auto-assigned tags
- Search functionality across titles, subtitles, and tags
- Multi-select tag filtering (AI, Engineering, Product, Productivity, Analysis)
- Client-side pagination (9 items per page)
- Responsive grid layout (1 col mobile, 2 col tablet, 3 col desktop)
- Cards with hover tooltips for truncated text
- Dev server now runs on port 2500

## Test plan

- [ ] Navigate to `/content` page
- [ ] Verify search filters posts correctly
- [ ] Test tag multi-select filtering
- [ ] Verify pagination works
- [ ] Check responsive layout on different screen sizes
- [ ] Verify external links open in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)